### PR TITLE
Fix message role mapping

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,6 +1,6 @@
 import { ChatOpenAI } from '@langchain/openai';
 import { LangChainAdapter, Message } from 'ai';
-import { AIMessage, HumanMessage } from '@langchain/core/messages';
+import { AIMessage, HumanMessage, SystemMessage } from '@langchain/core/messages';
 
 // Allow streaming responses up to 60 seconds
 export const maxDuration = 60;
@@ -9,10 +9,12 @@ export const maxDuration = 60;
 export async function POST(request: Request) {
   // message formatting
   const { messages, }: { messages: Message[] } = await request.json();
-  const formattedMessages = messages.map(message =>
-    message.role == 'user'
-        ? new HumanMessage({content: message.content})
-        : new AIMessage({content: message.content}),
+  const formattedMessages = messages.map((message) =>
+    message.role === 'user'
+      ? new HumanMessage({ content: message.content })
+      : message.role === 'system'
+        ? new SystemMessage({ content: message.content })
+        : new AIMessage({ content: message.content })
   );
    
   // model definition


### PR DESCRIPTION
## Summary
- handle `system` role messages in the chat API

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840f295e03c8332b780e0163ebbb231