### PR TITLE
Fix LangChain.js name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # assistant-ui-langchain-example
-This is an example of using assistant-ui with langchainjs libraries.
+This is an example of using assistant-ui with LangChain.js libraries.
 
 
 This is the [assistant-ui](https://github.com/Yonom/assistant-ui) starter project.


### PR DESCRIPTION
## Summary
- update README introduction to use proper LangChain.js brand

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6840f501714883328b05d189baa921e0